### PR TITLE
Fix name on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# The EPAMOS Game
+# The epamos Game
 
 A third-person game written by Sean McGuire, Mohammed Daudali and Patrick Ferris (PemScis 2020). 


### PR DESCRIPTION
As stated in the guidelines, epamos should always be lower-case letters. Fixes #1 .